### PR TITLE
Darker theme for app demo

### DIFF
--- a/demo-app.py
+++ b/demo-app.py
@@ -8,7 +8,7 @@ from dash.dependencies import Input, Output
 df = px.data.gapminder()
 
 
-app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
+app = dash.Dash(__name__, external_stylesheets=[dbc.themes.CYBORG])
 
 card_main = dbc.Card(
     [


### PR DESCRIPTION
This original Bootstrap theme is too white, as a result a few lighter lines on the line chart are hard to see. Changing the theme to CYBORG makes the background black, which solves the problem.